### PR TITLE
Split configs namespace into observability/network/configs

### DIFF
--- a/config/namespace-overrides.txt
+++ b/config/namespace-overrides.txt
@@ -2,13 +2,15 @@
 # Services not listed here deploy to the caller's default namespace.
 # Read by scripts/deploy-services.sh and .github/workflows/helm-deploy.yaml —
 # keep both in sync by only editing this file.
+# config/storage/values.yaml also hardcodes namespaces for some PV/PVCs
+# (e.g. prometheus-pvc) — keep those in sync with this file by hand too.
 factorio factorio
 minecraft minecraft
 image-cleanup configs
 configarr configs
 registry-cache configs
-kube-state-metrics configs
-prometheus configs
+kube-state-metrics observability
+prometheus observability
 grafana configs
-cloudflared configs
-twingate configs
+cloudflared network
+twingate network

--- a/config/namespace-overrides.txt
+++ b/config/namespace-overrides.txt
@@ -11,6 +11,6 @@ configarr configs
 registry-cache configs
 kube-state-metrics observability
 prometheus observability
-grafana configs
+grafana observability
 cloudflared network
 twingate network

--- a/config/storage/values.yaml
+++ b/config/storage/values.yaml
@@ -218,6 +218,10 @@ nas:
         storage: 10Gi
         accessMode: ReadWriteMany
         path: /volume1/docker/
+      - name: observability-config-pv
+        storage: 10Gi
+        accessMode: ReadWriteMany
+        path: /volume1/docker/
   pvc:
     data:
       - name: nas-pvc
@@ -248,5 +252,10 @@ nas:
         accessMode: ReadWriteMany
         persistentVolumeName: configs-config-pv
         namespace: configs
+      - name: observability-config-pvc
+        storage: 10Gi
+        accessMode: ReadWriteMany
+        persistentVolumeName: observability-config-pv
+        namespace: observability
 
 deploy: me

--- a/config/storage/values.yaml
+++ b/config/storage/values.yaml
@@ -184,7 +184,7 @@ nfs:
         storage: 10Gi
         accessMode: ReadWriteOnce
         persistentVolumeName: prometheus-pv
-        namespace: configs
+        namespace: observability
 
 nas:
   pv:

--- a/services/grafana/values.yaml
+++ b/services/grafana/values.yaml
@@ -36,12 +36,12 @@ persistence:
     subPath: grafana-config
   restore:
     enabled: true
-    existingClaim: configs-config-pvc
+    existingClaim: observability-config-pvc
     mountPath: /restore-source
     readOnly: true
   backup:
     enabled: true
-    existingClaim: configs-config-pvc
+    existingClaim: observability-config-pvc
     mountPath: /backup-dest
     readOnly: false
 


### PR DESCRIPTION
## Summary
- Splits the catch-all `configs` namespace by function: `observability` (prometheus, kube-state-metrics, grafana), `network` (cloudflared, twingate), and a narrowed `configs` (configarr, registry-cache, image-cleanup).
- Adds `observability-config-pv`/`-pvc` on the existing `/volume1/docker/` NFS export so grafana's restore/backup sidecars get their own namespace-scoped PVC instead of sharing `configs-config-pvc` with configarr.
- Already applied and verified live on the cluster: all four moved workloads (kube-state-metrics, cloudflared, twingate, prometheus, grafana) are running in their new namespaces, with prometheus/grafana data confirmed intact after re-binding their PVs.

## Test plan
- [x] `kubectl get pods -n observability|network|configs` — all healthy
- [x] prometheus WAL replay confirmed same data after PV rebind
- [x] grafana restore init container confirmed `grafana.db` and alerting config recovered from shared NFS path
- [x] twingate connector reconnected (State: Online) after redeploy

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>